### PR TITLE
fix bug of one less than needed wait count

### DIFF
--- a/3-synchronized/main.go
+++ b/3-synchronized/main.go
@@ -37,7 +37,7 @@ func main() {
 	}
 
 	var wg sync.WaitGroup
-	wg.Add(tp - fp)
+	wg.Add(tp - fp + 1)
 	for i := fp; i <= tp; i++ {
 		go func(p int) {
 			defer wg.Done()


### PR DESCRIPTION
It's off by one so program will exit while 1 port is still being scanned.  In the demo, port 8081 wasn't actually scanned.